### PR TITLE
Rstevanak/models trainer

### DIFF
--- a/pkspace/utils/trainer.py
+++ b/pkspace/utils/trainer.py
@@ -1,2 +1,0 @@
-def train(spaces, answers, model):
-    return model.fit(spaces, answers)

--- a/pkspace/utils/trainer.py
+++ b/pkspace/utils/trainer.py
@@ -1,0 +1,2 @@
+def train(spaces, answers, model):
+    return model.fit(spaces, answers)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,8 +1,6 @@
 import os
 import click
 import pickle
-import sys
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sklearn.neural_network import MLPClassifier
 from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
 from pkspace.utils import trainer
@@ -31,11 +29,13 @@ def train(dataset_mode, method, dataset_dir, output):
         loader = PKLotLoader()
 
     if method == 'MLP':
-        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10), random_state=1)
+        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10))
 
     spaces, answers = loader.load(dataset_dir)
     trained_model = trainer.train(spaces, answers, model)
     with open(output, 'wb') as out:
         pickle.dump(trained_model, out)
+
+
 if __name__ == '__main__':
     train()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,6 +1,4 @@
-import os
 import click
-import sys
 from sklearn.externals import joblib
 from sklearn.neural_network import MLPClassifier
 from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -16,11 +16,10 @@ from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader # noqa
               type=int,
               help='Hidden layers of MLP, if MLP is chosen as model_type')
 @click.option('--model_path', '-p', default=None,
-              type=click.Path(exists=True, dir_okay=False, file_okay=True,
-                              resolve_path=True),
+              type=click.Path(exists=True, dir_okay=False, resolve_path=True),
               help='Path to trained model, to be used as a base in training')
 @click.argument('dataset_dir',
-                type=click.Path(exists=True, file_okay=False, dir_okay=True,
+                type=click.Path(exists=True, file_okay=False,
                                 resolve_path=True))
 @click.option('--output', '-o', default='out.pkl', type=click.Path(),
               help='Path to output file for trained model')

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,7 +1,10 @@
+import os
 import click
+import sys
 from sklearn.externals import joblib
-from sklearn.neural_network import MLPClassifier
-from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from sklearn.neural_network import MLPClassifier # noqa
+from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader # noqa
 
 
 @click.command()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,10 +13,13 @@ from pkspace.utils import trainer
               default='PKSpace', help='Loader used to load dataset')
 @click.option('--model_type', '-mt', type=click.Choice(['MLP']), default='MLP',
               help='Type of model to be trained')
-@click.argument('dataset_dir')
+@click.option('--model_path', '-pm', type=click.Path(exists=True),
+              default=None,
+              help='Path to trained model, to be used as a base in training')
+@click.argument('dataset_dir', type=click.Path(exists=True))
 @click.option('--output', '-o', default='out.pkl',
-              help='Name of output file for trained model')
-def train(loader, model_type, dataset_dir, output):
+              help='Path to output file for trained model')
+def train(loader, model_type, model_path, dataset_dir, output):
     if not os.path.isdir(dataset_dir):
         sys.stderr.write('{} is not a directory'.format(dataset_dir))
         sys.exit(1)
@@ -26,7 +29,10 @@ def train(loader, model_type, dataset_dir, output):
     elif loader == 'PKLot':
         loader = PKLotLoader()
 
-    if model_type == 'MLP':
+    if model_path is not None:
+        with open(model_path, 'rb') as fp:
+            model = pickle.load(fp)
+    elif model_type == 'MLP':
         model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10))
 
     spaces, answers = loader.load(dataset_dir)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,34 +1,32 @@
 import os
 import click
 import pickle
+
+import sys
 from sklearn.neural_network import MLPClassifier
 from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
 from pkspace.utils import trainer
 
 
 @click.command()
-@click.option('--PKSpace', 'dataset_mode', flag_value='PKSpace',
-              default=True)
-@click.option('--PKLot', 'dataset_mode', flag_value='PKLot')
-@click.option('--MLP', 'method', flag_value='MLP',
-              default=True, help='Method to be used for prediction')
-@click.option('--dataset_dir', required=True,
-              help='Directory of dataset for model to be trained on')
-@click.option('--output', default=None,
+@click.option('--loader', '-t', type=click.Choice(['PKLot', 'PKSpace']),
+              default='PKSpace', help='Loader used to load dataset')
+@click.option('--model_type', '-mt', type=click.Choice(['MLP']), default='MLP',
+              help='Type of model to be trained')
+@click.argument('dataset_dir')
+@click.option('--output', '-o', default='out.pkl',
               help='Name of output file for trained model')
-def train(dataset_mode, method, dataset_dir, output):
+def train(loader, model_type, dataset_dir, output):
     if not os.path.isdir(dataset_dir):
-        print('{} is not a directory')
-        return
+        print('{} is not a directory'.format(dataset_dir), file=sys.stderr)
+        sys.exit(1)
 
-    if output is None:
-        output = os.path.join(dataset_dir, 'out.pkl')
-    if dataset_mode == 'PKSpace':
+    if loader == 'PKSpace':
         loader = PKSpaceLoader()
-    elif dataset_mode == 'PKLot':
+    elif loader == 'PKLot':
         loader = PKLotLoader()
 
-    if method == 'MLP':
+    if model_type == 'MLP':
         model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10))
 
     spaces, answers = loader.load(dataset_dir)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,41 @@
+import os
+import click
+import pickle
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from sklearn.neural_network import MLPClassifier
+from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
+from pkspace.utils import trainer
+
+
+@click.command()
+@click.option('--PKSpace', 'dataset_mode', flag_value='PKSpace',
+              default=True)
+@click.option('--PKLot', 'dataset_mode', flag_value='PKLot')
+@click.option('--MLP', 'method', flag_value='MLP',
+              default=True, help='Method to be used for prediction')
+@click.option('--dataset_dir', required=True,
+              help='Directory of dataset for model to be trained on')
+@click.option('--output', default=None,
+              help='Name of output file for trained model')
+def train(dataset_mode, method, dataset_dir, output):
+    if not os.path.isdir(dataset_dir):
+        print('{} is not a directory')
+        return
+
+    if output is None:
+        output = os.path.join(dataset_dir, 'out.pkl')
+    if dataset_mode == 'PKSpace':
+        loader = PKSpaceLoader()
+    elif dataset_mode == 'PKLot':
+        loader = PKLotLoader()
+
+    if method == 'MLP':
+        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10), random_state=1)
+
+    spaces, answers = loader.load(dataset_dir)
+    trained_model = trainer.train(spaces, answers, model)
+    with open(output, 'wb') as out:
+        pickle.dump(trained_model, out)
+if __name__ == '__main__':
+    train()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,19 +11,17 @@ from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
               default='PKSpace', help='Loader used to load dataset')
 @click.option('--model_type', '-t', type=click.Choice(['MLP']), default='MLP',
               help='Type of model to be trained')
-@click.option('--hidden_layer', '-h', default="15 10",
+@click.option('--hidden_layer', '-h', default=(15, 10), multiple=True,
+              type=int,
               help='Hidden layers of MLP, if MLP is chosen as model_type')
-@click.option('--model_path', '-p', type=click.Path(exists=True),
-              default=None,
+@click.option('--model_path', '-p', default=None,
+              type=click.Path(exists=True, dir_okay=False, file_okay=True),
               help='Path to trained model, to be used as a base in training')
-@click.argument('dataset_dir', type=click.Path(exists=True))
-@click.option('--output', '-o', default='out.pkl',
+@click.argument('dataset_dir',
+                type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option('--output', '-o', default='out.pkl', type=click.Path(),
               help='Path to output file for trained model')
 def train(loader, model_type, hidden_layer, model_path, dataset_dir, output):
-    if not os.path.isdir(dataset_dir):
-        sys.stderr.write('{} is not a directory'.format(dataset_dir))
-        sys.exit(1)
-
     if loader == 'PKSpace':
         loader = PKSpaceLoader()
     elif loader == 'PKLot':
@@ -33,12 +31,7 @@ def train(loader, model_type, hidden_layer, model_path, dataset_dir, output):
         model = joblib.load(model_path)
 
     elif model_type == 'MLP':
-        layers = hidden_layer.split()
-        try:
-            layers = [int(x) for x in layers]
-        except ValueError:
-            sys.stderr.write("--hidden_layer must be ints separated by spaces")
-        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=layers)
+        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=hidden_layer)
 
     spaces, answers = loader.load(dataset_dir)
     trained_model = model.fit(spaces, answers)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,10 +13,12 @@ from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
               type=int,
               help='Hidden layers of MLP, if MLP is chosen as model_type')
 @click.option('--model_path', '-p', default=None,
-              type=click.Path(exists=True, dir_okay=False, file_okay=True),
+              type=click.Path(exists=True, dir_okay=False, file_okay=True,
+                              resolve_path=True),
               help='Path to trained model, to be used as a base in training')
 @click.argument('dataset_dir',
-                type=click.Path(exists=True, file_okay=False, dir_okay=True))
+                type=click.Path(exists=True, file_okay=False, dir_okay=True,
+                                resolve_path=True))
 @click.option('--output', '-o', default='out.pkl', type=click.Path(),
               help='Path to output file for trained model')
 def train(loader, model_type, hidden_layer, model_path, dataset_dir, output):

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -9,17 +9,17 @@ from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader
 @click.command()
 @click.option('--loader', '-l', type=click.Choice(['PKLot', 'PKSpace']),
               default='PKSpace', help='Loader used to load dataset')
-@click.option('--model_type', '-mt', type=click.Choice(['MLP']), default='MLP',
+@click.option('--model_type', '-t', type=click.Choice(['MLP']), default='MLP',
               help='Type of model to be trained')
-# @click.option('--hidden_later', '-hl', default=(15, 10),
-#               help='Hidden layers of MLP, if MLP is chosen as model_type')
-@click.option('--model_path', '-pm', type=click.Path(exists=True),
+@click.option('--hidden_layer', '-h', default="15 10",
+              help='Hidden layers of MLP, if MLP is chosen as model_type')
+@click.option('--model_path', '-p', type=click.Path(exists=True),
               default=None,
               help='Path to trained model, to be used as a base in training')
 @click.argument('dataset_dir', type=click.Path(exists=True))
 @click.option('--output', '-o', default='out.pkl',
               help='Path to output file for trained model')
-def train(loader, model_type, model_path, dataset_dir, output):
+def train(loader, model_type, hidden_layer, model_path, dataset_dir, output):
     if not os.path.isdir(dataset_dir):
         sys.stderr.write('{} is not a directory'.format(dataset_dir))
         sys.exit(1)
@@ -29,21 +29,19 @@ def train(loader, model_type, model_path, dataset_dir, output):
     elif loader == 'PKLot':
         loader = PKLotLoader()
 
-    spaces, answers = loader.load(dataset_dir)
-
     if model_path is not None:
         model = joblib.load(model_path)
 
-        if not callable(getattr(model, 'partial_fit', None)):
-            sys.stderr.write('{} is not further trainable'.format(model_path))
-            sys.exit(1)
-
-        trained_model = model.partial_fit(spaces, answers)
-
     elif model_type == 'MLP':
-        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=(15, 10))
+        layers = hidden_layer.split()
+        try:
+            layers = [int(x) for x in layers]
+        except ValueError:
+            sys.stderr.write("--hidden_layer must be ints separated by spaces")
+        model = MLPClassifier(solver='lbfgs', hidden_layer_sizes=layers)
 
-        trained_model = model.partial_fit(spaces, answers, [0, 1])
+    spaces, answers = loader.load(dataset_dir)
+    trained_model = model.fit(spaces, answers)
 
     joblib.dump(trained_model, output, protocol=0)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,7 +18,7 @@ from pkspace.utils import trainer
               help='Name of output file for trained model')
 def train(loader, model_type, dataset_dir, output):
     if not os.path.isdir(dataset_dir):
-        print('{} is not a directory'.format(dataset_dir), file=sys.stderr)
+        sys.stderr.write('{} is not a directory'.format(dataset_dir))
         sys.exit(1)
 
     if loader == 'PKSpace':

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -9,7 +9,7 @@ from pkspace.utils import trainer
 
 
 @click.command()
-@click.option('--loader', '-t', type=click.Choice(['PKLot', 'PKSpace']),
+@click.option('--loader', '-l', type=click.Choice(['PKLot', 'PKSpace']),
               default='PKSpace', help='Loader used to load dataset')
 @click.option('--model_type', '-mt', type=click.Choice(['MLP']), default='MLP',
               help='Type of model to be trained')

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,7 +1,6 @@
 import os
 import click
 import pickle
-
 import sys
 from sklearn.neural_network import MLPClassifier
 from pkspace.utils.loaders import PKSpaceLoader, PKLotLoader


### PR DESCRIPTION
Testing can be done by running python -m scripts.train .... This is because I tried to avoid problem with importing from neighboring package unlike in predict script, where it will be fixed shortly.
As of yet there is not implemented training of an already trained model, and only trainable model is new MLP, but adding more models won't be a problem.